### PR TITLE
Add websocket-controlled tower placement

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,25 @@ src/
 - `yarn lint` - Run ESLint
 - `yarn preview` - Preview production build locally
 
+### Command server for remote placement
+
+The client can subscribe to WebSocket commands to place towers remotely. A
+lightweight broadcaster is included for local testing:
+
+```bash
+yarn command-server
+```
+
+The script listens on `ws://localhost:3001` by default (override with
+`COMMAND_SERVER_PORT`). Each connected client receives whatever payload you
+enter. Either paste raw JSON messages or use the helper syntax:
+
+- `place <x> <y> <towerType>` – shorthand for
+  `{ "type": "place_tower", "position": { "x": x, "y": y }, "towerType": towerType }`
+
+Tower types correspond to the keys exported by
+[`towers/TowerFactory.ts`](src/towers/TowerFactory.ts).
+
 ## Contributing
 
 Contributions are welcome! Please feel free to submit a Pull Request.

--- a/README.md
+++ b/README.md
@@ -148,6 +148,27 @@ enter. Either paste raw JSON messages or use the helper syntax:
 Tower types correspond to the keys exported by
 [`towers/TowerFactory.ts`](src/towers/TowerFactory.ts).
 
+For automation or integration tests, you can run a REST wrapper that exposes an
+HTTP endpoint while still broadcasting via WebSocket:
+
+```bash
+yarn command-server-rest
+```
+
+This server listens on both `http://localhost:3001` and `ws://localhost:3001`
+by default (override with `COMMAND_SERVER_PORT`). To place a tower via HTTP,
+send a JSON payload containing the `x`, `y`, and `towerType` fields:
+
+```bash
+curl -X POST \
+  -H "Content-Type: application/json" \
+  -d '{"x":6,"y":4,"towerType":"SPIKE"}' \
+  http://localhost:3001/towers
+```
+
+A successful request responds with `201 Created` and broadcasts the equivalent
+`place_tower` command to all connected WebSocket clients.
+
 ## Contributing
 
 Contributions are welcome! Please feel free to submit a Pull Request.

--- a/package.json
+++ b/package.json
@@ -4,8 +4,9 @@
   "version": "0.0.0",
   "type": "module",
   "scripts": {
-    "dev": "vite",
     "build": "tsc -b && vite build",
+    "command-server": "node scripts/commandServer.mjs",
+    "dev": "vite",
     "lint": "eslint .",
     "preview": "vite preview"
   },
@@ -29,6 +30,7 @@
     "globals": "^15.15.0",
     "typescript": "~5.7.2",
     "typescript-eslint": "^8.24.1",
-    "vite": "^6.2.0"
+    "vite": "^6.2.0",
+    "ws": "^8.18.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "build": "tsc -b && vite build",
     "command-server": "node scripts/commandServer.mjs",
+    "command-server-rest": "node scripts/restCommandServer.mjs",
     "dev": "vite",
     "lint": "eslint .",
     "preview": "vite preview"

--- a/scripts/commandServer.mjs
+++ b/scripts/commandServer.mjs
@@ -1,0 +1,128 @@
+import { WebSocketServer } from "ws";
+import readline from "node:readline";
+import process from "node:process";
+
+const port = Number.parseInt(process.env.COMMAND_SERVER_PORT ?? "3001", 10);
+
+if (Number.isNaN(port)) {
+  console.error("COMMAND_SERVER_PORT must be a valid number");
+  process.exit(1);
+}
+
+const wss = new WebSocketServer({ port });
+
+const clients = new Set();
+
+wss.on("connection", (socket, request) => {
+  clients.add(socket);
+
+  const clientId = `${request.socket.remoteAddress ?? "unknown"}:${
+    request.socket.remotePort ?? "?"
+  }`;
+
+  console.log(`Client connected (${clientId}). Active clients: ${clients.size}`);
+
+  socket.on("close", () => {
+    clients.delete(socket);
+    console.log(
+      `Client disconnected (${clientId}). Active clients: ${clients.size}`,
+    );
+  });
+
+  socket.on("error", (error) => {
+    clients.delete(socket);
+    console.error(`Client error (${clientId}):`, error);
+  });
+});
+
+const broadcast = (payload) => {
+  const message = JSON.stringify(payload);
+  let sent = 0;
+
+  clients.forEach((client) => {
+    if (client.readyState === client.OPEN) {
+      client.send(message);
+      sent += 1;
+    }
+  });
+
+  console.log(`Sent command to ${sent} client${sent === 1 ? "" : "s"}.`);
+};
+
+const rl = readline.createInterface({
+  input: process.stdin,
+  output: process.stdout,
+  prompt: "command> ",
+});
+
+console.log(
+  `Command server listening on ws://localhost:${port}\n` +
+    "Type JSON payloads or use 'place <x> <y> <towerType>'.\n" +
+    "Tower types map to entries in towers/TowerFactory.ts.",
+);
+
+rl.prompt();
+
+const handleLine = (line) => {
+  const trimmed = line.trim();
+  if (!trimmed) {
+    rl.prompt();
+    return;
+  }
+
+  if (trimmed.startsWith("place ")) {
+    const [, xStr, yStr, type] = trimmed.split(/\s+/);
+
+    const x = Number.parseInt(xStr, 10);
+    const y = Number.parseInt(yStr, 10);
+
+    if (Number.isNaN(x) || Number.isNaN(y) || !type) {
+      console.error(
+        "Usage: place <x> <y> <towerType> (e.g. 'place 6 4 SPIKE')",
+      );
+      rl.prompt();
+      return;
+    }
+
+    broadcast({
+      type: "place_tower",
+      position: { x, y },
+      towerType: type,
+    });
+    rl.prompt();
+    return;
+  }
+
+  try {
+    const payload = JSON.parse(trimmed);
+    broadcast(payload);
+  } catch (error) {
+    console.error(
+      "Could not parse input as JSON or place command.\n" +
+        "Example: {\"type\":\"place_tower\",\"position\":{\"x\":6,\"y\":4},\"towerType\":\"SPIKE\" }",
+    );
+  }
+
+  rl.prompt();
+};
+
+rl.on("line", handleLine);
+rl.on("SIGINT", () => {
+  rl.close();
+});
+
+const shutdown = () => {
+  console.log("\nShutting down command server...");
+  rl.close();
+  wss.close(() => {
+    process.exit(0);
+  });
+
+  setTimeout(() => {
+    process.exit(0);
+  }, 100).unref();
+};
+
+process.on("SIGINT", shutdown);
+process.on("SIGTERM", shutdown);
+

--- a/scripts/restCommandServer.mjs
+++ b/scripts/restCommandServer.mjs
@@ -1,0 +1,202 @@
+import { createServer } from "node:http";
+import process from "node:process";
+import { WebSocketServer } from "ws";
+
+const port = Number.parseInt(process.env.COMMAND_SERVER_PORT ?? "3001", 10);
+
+if (Number.isNaN(port)) {
+  console.error("COMMAND_SERVER_PORT must be a valid number");
+  process.exit(1);
+}
+
+const clients = new Set();
+
+const httpServer = createServer(async (req, res) => {
+  if (!req.url) {
+    sendJson(res, 400, {
+      error: "Invalid request",
+      details: "Missing request URL",
+    });
+    return;
+  }
+
+  const url = new URL(req.url, `http://localhost:${port}`);
+
+  if (req.method === "POST" && url.pathname === "/towers") {
+    try {
+      const body = await readRequestBody(req);
+      const validationError = validateTowerPayload(body);
+
+      if (validationError) {
+        sendJson(res, 400, { error: "Invalid payload", details: validationError });
+        return;
+      }
+
+      const payload = {
+        type: "place_tower",
+        position: { x: body.x, y: body.y },
+        towerType: body.towerType,
+      };
+
+      broadcast(payload);
+      sendJson(res, 201, { status: "ok" });
+    } catch (error) {
+      if (error instanceof SyntaxError) {
+        sendJson(res, 400, {
+          error: "Invalid JSON",
+          details: "Request body must be valid JSON",
+        });
+        return;
+      }
+
+      if ((error?.code ?? null) === "PAYLOAD_TOO_LARGE") {
+        sendJson(res, 400, {
+          error: "Invalid payload",
+          details: "Payload too large",
+        });
+        return;
+      }
+
+      console.error("Error handling request:", error);
+      sendJson(res, 500, {
+        error: "Internal server error",
+      });
+    }
+
+    return;
+  }
+
+  if (req.method === "OPTIONS" && url.pathname === "/towers") {
+    res.statusCode = 204;
+    res.setHeader("Access-Control-Allow-Origin", "*");
+    res.setHeader("Access-Control-Allow-Methods", "POST, OPTIONS");
+    res.setHeader("Access-Control-Allow-Headers", "Content-Type");
+    res.end();
+    return;
+  }
+
+  sendJson(res, 404, { error: "Not found" });
+});
+
+const wss = new WebSocketServer({ server: httpServer });
+
+wss.on("connection", (socket, request) => {
+  clients.add(socket);
+
+  const clientId = `${request.socket.remoteAddress ?? "unknown"}:${
+    request.socket.remotePort ?? "?"
+  }`;
+
+  console.log(`Client connected (${clientId}). Active clients: ${clients.size}`);
+
+  socket.on("close", () => {
+    clients.delete(socket);
+    console.log(
+      `Client disconnected (${clientId}). Active clients: ${clients.size}`,
+    );
+  });
+
+  socket.on("error", (error) => {
+    clients.delete(socket);
+    console.error(`Client error (${clientId}):`, error);
+  });
+});
+
+const broadcast = (payload) => {
+  const message = JSON.stringify(payload);
+  let sent = 0;
+
+  clients.forEach((client) => {
+    if (client.readyState === client.OPEN) {
+      client.send(message);
+      sent += 1;
+    }
+  });
+
+  console.log(`Sent command to ${sent} client${sent === 1 ? "" : "s"}.`);
+};
+
+httpServer.listen(port, () => {
+  console.log(
+    `REST command server listening on http://localhost:${port} and ws://localhost:${port}`,
+  );
+});
+
+const shutdown = () => {
+  console.log("\nShutting down REST command server...");
+  httpServer.close(() => {
+    wss.close(() => {
+      process.exit(0);
+    });
+  });
+
+  setTimeout(() => {
+    process.exit(0);
+  }, 100).unref();
+};
+
+process.on("SIGINT", shutdown);
+process.on("SIGTERM", shutdown);
+
+function sendJson(res, statusCode, payload) {
+  res.statusCode = statusCode;
+  res.setHeader("Content-Type", "application/json");
+  res.setHeader("Access-Control-Allow-Origin", "*");
+  res.end(JSON.stringify(payload));
+}
+
+function validateTowerPayload(body) {
+  if (typeof body !== "object" || body === null) {
+    return "Body must be a JSON object";
+  }
+
+  const { x, y, towerType } = body;
+
+  if (typeof x !== "number" || !Number.isFinite(x)) {
+    return "'x' must be a finite number";
+  }
+
+  if (typeof y !== "number" || !Number.isFinite(y)) {
+    return "'y' must be a finite number";
+  }
+
+  if (typeof towerType !== "string" || towerType.trim() === "") {
+    return "'towerType' must be a non-empty string";
+  }
+
+  return null;
+}
+
+function readRequestBody(req) {
+  return new Promise((resolve, reject) => {
+    let data = "";
+    req.setEncoding("utf8");
+
+    req.on("data", (chunk) => {
+      data += chunk;
+      if (data.length > 1_000_000) {
+        const error = new Error("Payload too large");
+        error.code = "PAYLOAD_TOO_LARGE";
+        req.destroy(error);
+        reject(error);
+      }
+    });
+
+    req.on("end", () => {
+      if (data.length === 0) {
+        resolve({});
+        return;
+      }
+
+      try {
+        resolve(JSON.parse(data));
+      } catch (error) {
+        reject(new SyntaxError("Invalid JSON"));
+      }
+    });
+
+    req.on("error", (error) => {
+      reject(error);
+    });
+  });
+}

--- a/src/components/GameCanvas/GameCanvas.tsx
+++ b/src/components/GameCanvas/GameCanvas.tsx
@@ -1,5 +1,5 @@
 import { tileConfig } from "../../constants";
-import { memo, useRef, useState } from "react";
+import { memo, useEffect, useRef, useState } from "react";
 import { useGameLoop } from "./hooks/useGameLoop";
 import { useGameInit } from "./hooks/useGameInit";
 import { useAddTower } from "./hooks/useAddTower";
@@ -17,6 +17,7 @@ import {
   CurrencyDollarIcon,
   UserGroupIcon,
 } from "@heroicons/react/24/outline";
+import { useServerCommands } from "./hooks/useServerCommands";
 
 interface Props {
   mapGrid: number[][];
@@ -35,12 +36,23 @@ export const GameCanvas = memo(({ mapGrid, setCurrentLevel }: Props) => {
     TowerType.SPIKE
   );
 
-  const { addTower } = useAddTower({
+  const goldRef = useRef(gold);
+
+  useEffect(() => {
+    goldRef.current = gold;
+  }, [gold]);
+
+  const { addTower, placeTower } = useAddTower({
     mapGrid,
     game,
     gameCanvasRef,
-    gold,
+    goldRef,
     selectedTowerType,
+  });
+
+  useServerCommands({
+    game,
+    placeTower,
   });
 
   return (

--- a/src/components/GameCanvas/hooks/useServerCommands.ts
+++ b/src/components/GameCanvas/hooks/useServerCommands.ts
@@ -1,0 +1,105 @@
+import { useEffect } from "react";
+import { Game } from "../../../game/Game";
+import { TowerType } from "../../../towers/TowerFactory";
+
+type PlaceTowerCommand = {
+  type: "place_tower";
+  position: { x: number; y: number };
+  towerType?: string;
+  tower_type?: string;
+};
+
+type ServerCommand = Record<string, unknown>;
+
+interface Args {
+  game: Game | null;
+  placeTower: (
+    position: { x: number; y: number },
+    towerType: TowerType
+  ) => boolean | void;
+}
+
+const parseTowerType = (type: unknown): TowerType | null => {
+  if (typeof type !== "string") return null;
+
+  const normalized = type.toUpperCase();
+
+  if ((Object.values(TowerType) as string[]).includes(normalized)) {
+    return normalized as TowerType;
+  }
+
+  if (normalized in TowerType) {
+    return TowerType[normalized as keyof typeof TowerType];
+  }
+
+  return null;
+};
+
+const isPlaceTowerCommand = (
+  command: ServerCommand
+): command is PlaceTowerCommand => {
+  if (!command || typeof command !== "object") return false;
+
+  return (command as { type?: unknown }).type === "place_tower";
+};
+
+const resolveSocketUrl = () =>
+  import.meta.env.VITE_COMMANDS_WS_URL ??
+  import.meta.env.VITE_GAME_SERVER_WS ??
+  "ws://localhost:3001";
+
+export const useServerCommands = ({ game, placeTower }: Args) => {
+  useEffect(() => {
+    if (!game) return;
+    if (typeof window === "undefined") return;
+    if (typeof WebSocket === "undefined") return;
+
+    const url = resolveSocketUrl();
+
+    let socket: WebSocket | null = null;
+
+    try {
+      socket = new WebSocket(url);
+    } catch (error) {
+      console.error("Failed to connect to command socket", error);
+      return;
+    }
+
+    socket.onmessage = (event) => {
+      try {
+        const command: ServerCommand = JSON.parse(event.data);
+
+        if (!isPlaceTowerCommand(command)) return;
+
+        const towerType =
+          parseTowerType(command.towerType) ?? parseTowerType(command.tower_type);
+        if (!towerType) {
+          console.warn("Unknown tower type received from server", command);
+          return;
+        }
+
+        const { position } = command;
+        if (
+          !position ||
+          typeof position.x !== "number" ||
+          typeof position.y !== "number"
+        ) {
+          console.warn("Invalid tower position received from server", command);
+          return;
+        }
+
+        placeTower({ x: position.x, y: position.y }, towerType);
+      } catch (error) {
+        console.error("Failed to process server command", error);
+      }
+    };
+
+    socket.onerror = (event) => {
+      console.error("Command socket error", event);
+    };
+
+    return () => {
+      socket?.close();
+    };
+  }, [game, placeTower]);
+};

--- a/src/components/MapCanvas/MapCanvas.tsx
+++ b/src/components/MapCanvas/MapCanvas.tsx
@@ -9,18 +9,139 @@ export const MapCanvas = () => {
   const mapCanvasRef = useRef<HTMLCanvasElement>(null);
   const { mapGrid } = useMapInit(mapCanvasRef, currentLevel);
 
+  const mapWidthPx = tileConfig.mapWidth * tileConfig.tileSize;
+  const mapHeightPx = tileConfig.mapHeight * tileConfig.tileSize;
+  const axisOffset = 24;
+  const xAxisLabels = Array.from({ length: tileConfig.mapWidth }, (_, x) => x);
+  const yAxisLabels = Array.from({ length: tileConfig.mapHeight }, (_, y) => y);
+
   return (
     <>
       <h2>Level: {currentLevel}</h2>
-      <div style={{ position: "relative" }}>
+      <div
+        style={{
+          position: "relative",
+          margin: `${axisOffset}px`,
+        }}
+      >
         <canvas
           ref={mapCanvasRef}
-          width={tileConfig.mapWidth * tileConfig.tileSize}
-          height={tileConfig.mapHeight * tileConfig.tileSize}
+          width={mapWidthPx}
+          height={mapHeightPx}
           style={{ border: "1px solid black" }}
         />
 
         <GameCanvas mapGrid={mapGrid} setCurrentLevel={setCurrentLevel} />
+
+        <div
+          style={{
+            position: "absolute",
+            top: -axisOffset,
+            left: 0,
+            width: mapWidthPx,
+            display: "flex",
+            color: "#fff",
+            fontSize: "0.75rem",
+            fontFamily: "monospace",
+            zIndex: 20,
+          }}
+        >
+          {xAxisLabels.map((label) => (
+            <span
+              key={`top-${label}`}
+              style={{
+                width: tileConfig.tileSize,
+                textAlign: "center",
+              }}
+            >
+              {label}
+            </span>
+          ))}
+        </div>
+
+        <div
+          style={{
+            position: "absolute",
+            bottom: -axisOffset,
+            left: 0,
+            width: mapWidthPx,
+            display: "flex",
+            color: "#fff",
+            fontSize: "0.75rem",
+            fontFamily: "monospace",
+            zIndex: 20,
+          }}
+        >
+          {xAxisLabels.map((label) => (
+            <span
+              key={`bottom-${label}`}
+              style={{
+                width: tileConfig.tileSize,
+                textAlign: "center",
+              }}
+            >
+              {label}
+            </span>
+          ))}
+        </div>
+
+        <div
+          style={{
+            position: "absolute",
+            left: -axisOffset,
+            top: 0,
+            height: mapHeightPx,
+            display: "flex",
+            flexDirection: "column",
+            color: "#fff",
+            fontSize: "0.75rem",
+            fontFamily: "monospace",
+            zIndex: 20,
+          }}
+        >
+          {yAxisLabels.map((label) => (
+            <span
+              key={`left-${label}`}
+              style={{
+                height: tileConfig.tileSize,
+                display: "flex",
+                alignItems: "center",
+                justifyContent: "center",
+              }}
+            >
+              {label}
+            </span>
+          ))}
+        </div>
+
+        <div
+          style={{
+            position: "absolute",
+            right: -axisOffset,
+            top: 0,
+            height: mapHeightPx,
+            display: "flex",
+            flexDirection: "column",
+            color: "#fff",
+            fontSize: "0.75rem",
+            fontFamily: "monospace",
+            zIndex: 20,
+          }}
+        >
+          {yAxisLabels.map((label) => (
+            <span
+              key={`right-${label}`}
+              style={{
+                height: tileConfig.tileSize,
+                display: "flex",
+                alignItems: "center",
+                justifyContent: "center",
+              }}
+            >
+              {label}
+            </span>
+          ))}
+        </div>
       </div>
     </>
   );

--- a/yarn.lock
+++ b/yarn.lock
@@ -1831,6 +1831,11 @@ word-wrap@^1.2.5:
   resolved "https://registry.yarnpkg.com/word-wrap/-/word-wrap-1.2.5.tgz#d2c45c6dd4fbce621a66f136cbe328afd0410b34"
   integrity sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==
 
+ws@^8.18.3:
+  version "8.18.3"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-8.18.3.tgz#b56b88abffde62791c639170400c93dcb0c95472"
+  integrity sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==
+
 yallist@^3.0.2:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-3.1.1.tgz#dbb7daf9bfd8bac9ab45ebf602b8cbad0d5d08fd"


### PR DESCRIPTION
## Summary
- expose a reusable tower placement helper that shares validation with the click handler
- connect the game canvas to a websocket listener so server commands can build towers
- add a hook that parses `place_tower` messages from the backend and applies them in-game

## Testing
- npx eslint .

------
https://chatgpt.com/codex/tasks/task_e_68d6eeb1d8688327a54edf197e735fe9