### PR TITLE
Add board status endpoint to REST command server

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,16 @@ curl -X POST \
 A successful request responds with `201 Created` and broadcasts the equivalent
 `place_tower` command to all connected WebSocket clients.
 
+To inspect the current board state tracked by the REST server, send a `GET`
+request to `/board`:
+
+```bash
+curl http://localhost:3001/board
+```
+
+The response includes a JSON object with a `towers` array describing the latest
+known tower placements (by coordinate and tower type).
+
 ## Contributing
 
 Contributions are welcome! Please feel free to submit a Pull Request.

--- a/README.md
+++ b/README.md
@@ -177,7 +177,9 @@ curl http://localhost:3001/board
 ```
 
 The response includes a JSON object with a `towers` array describing the latest
-known tower placements (by coordinate and tower type).
+known tower placements (by coordinate and tower type). When the browser client
+loads, it will fetch this endpoint and replay the returned placements so that a
+page refresh remains in sync with the REST server's view of the board.
 
 ## Contributing
 


### PR DESCRIPTION
## Summary
- track tower placements within the REST command server
- add a GET /board endpoint that exposes the current tower layout
- document the new endpoint and example usage in the README

## Testing
- yarn lint

------
https://chatgpt.com/codex/tasks/task_e_68d70ac388d8832781f442c110537328