### PR TITLE
Add Docker support and OpenShift deployment manifests

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,20 @@
+# syntax=docker/dockerfile:1.6
+
+# Build the static assets with Vite
+FROM node:22-alpine AS build
+WORKDIR /app
+ENV NODE_ENV=production
+COPY package.json yarn.lock ./
+RUN corepack enable \
+    && yarn install --frozen-lockfile
+COPY . .
+RUN yarn build
+
+# Serve the compiled application with a lightweight HTTP server
+FROM node:22-alpine AS runtime
+WORKDIR /app
+RUN npm install -g serve
+COPY --from=build /app/dist ./dist
+USER node
+EXPOSE 8080
+CMD ["serve", "-s", "dist", "-l", "8080", "--no-clipboard"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,32 @@
 # syntax=docker/dockerfile:1.6
 
-# Build the static assets with Vite
-FROM node:22-alpine AS build
+# Install dependencies once and share across build targets
+FROM node:22-alpine AS deps
 WORKDIR /app
-ENV NODE_ENV=production
 COPY package.json yarn.lock ./
 RUN corepack enable \
+    && corepack prepare yarn@1.22.22 --activate \
     && yarn install --frozen-lockfile
+
+# Provide a runtime for the REST command server
+FROM node:22-alpine AS rest-command-server
+WORKDIR /app
+ENV NODE_ENV=production
+ENV COMMAND_SERVER_PORT=3001
+COPY --from=deps /app/node_modules ./node_modules
+COPY package.json yarn.lock ./
+COPY scripts ./scripts
+USER node
+EXPOSE 3001
+CMD ["node", "scripts/restCommandServer.mjs"]
+
+# Build the static assets with Vite
+FROM deps AS build
 COPY . .
 RUN yarn build
 
 # Serve the compiled application with a lightweight HTTP server
-FROM node:22-alpine AS runtime
+FROM node:22-alpine AS frontend-runtime
 WORKDIR /app
 RUN npm install -g serve
 COPY --from=build /app/dist ./dist

--- a/openshift/deployment.yaml
+++ b/openshift/deployment.yaml
@@ -1,0 +1,64 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: tower-defense
+  labels:
+    app: tower-defense
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: tower-defense
+  template:
+    metadata:
+      labels:
+        app: tower-defense
+    spec:
+      containers:
+        - name: tower-defense
+          image: quay.io/example/tower-defense:latest
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 8080
+          env:
+            - name: NODE_ENV
+              value: production
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 8080
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 8080
+            initialDelaySeconds: 15
+            periodSeconds: 20
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: tower-defense
+  labels:
+    app: tower-defense
+spec:
+  selector:
+    app: tower-defense
+  ports:
+    - name: http
+      port: 80
+      targetPort: 8080
+---
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: tower-defense
+  labels:
+    app: tower-defense
+spec:
+  to:
+    kind: Service
+    name: tower-defense
+  port:
+    targetPort: http

--- a/openshift/rest-command-server.yaml
+++ b/openshift/rest-command-server.yaml
@@ -1,0 +1,65 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: tower-defense-rest-command-server
+  labels:
+    app: tower-defense-rest-command-server
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: tower-defense-rest-command-server
+  template:
+    metadata:
+      labels:
+        app: tower-defense-rest-command-server
+    spec:
+      containers:
+        - name: rest-command-server
+          image: quay.io/example/tower-defense-rest-command-server:latest
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: COMMAND_SERVER_PORT
+              value: "3001"
+          ports:
+            - containerPort: 3001
+              name: http
+          readinessProbe:
+            httpGet:
+              path: /board
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /board
+              port: http
+            initialDelaySeconds: 15
+            periodSeconds: 20
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: tower-defense-rest-command-server
+  labels:
+    app: tower-defense-rest-command-server
+spec:
+  selector:
+    app: tower-defense-rest-command-server
+  ports:
+    - name: http
+      port: 80
+      targetPort: http
+---
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: tower-defense-rest-command-server
+  labels:
+    app: tower-defense-rest-command-server
+spec:
+  to:
+    kind: Service
+    name: tower-defense-rest-command-server
+  port:
+    targetPort: http


### PR DESCRIPTION
## Summary
- add a multi-stage Dockerfile to build the Vite application and serve the production bundle
- provide OpenShift deployment, service, and route resources for running the container image

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d7131954248327b202493c1a04fefa